### PR TITLE
Increase radius of ores

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -4,28 +4,28 @@ konstructs {
     ores {
       org/konstructs/ore/tin-ore {
         spawns-in = org/konstructs/stone
-        radius = 3
+        radius = 4
         generations = 3
         probability = 750
         max-distance = 15
       }
       org/konstructs/ore/iron-ore {
         spawns-in = org/konstructs/stone
-        radius = 3
+        radius = 4
         generations = 3
         probability = 1000
         max-distance = 10
       }
       org/konstructs/ore/gold-nuggets {
         spawns-in = org/konstructs/stone
-        radius = 4
+        radius = 5
         generations = 5
         probability = 150
         max-distance = 10
       }
       org/konstructs/ore/silver-nuggets {
         spawns-in = org/konstructs/stone
-        radius = 5
+        radius = 6
         generations = 6
         probability = 300
         max-distance = 15


### PR DESCRIPTION
- This avoids growing out of walls
- This makes them more rare